### PR TITLE
Update darcula.css

### DIFF
--- a/themeDarcula/darcula.css
+++ b/themeDarcula/darcula.css
@@ -13,6 +13,10 @@
   color: #2b91af;
   border-right: 0;
 }
+.CodeMirror-focused .CodeMirror-activeline-background, 
+.CodeMirror-focused .CodeMirror-activeline .CodeMirror-gutter-elt {
+    background-color: #333;
+}
 .cm-keyword {
   color: #cc7833;
 }


### PR DESCRIPTION
Your theme is wonderful, but when I use "view -> hightlight active line", the active line has a bright white background and the text over it is quite unreadable.
I think that a dark grey background for the highlighted line would be better suited.
